### PR TITLE
update to 2017

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
       }
     },
     "debug": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
-      "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -800,9 +800,9 @@
       "dev": true
     },
     "regexpp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
-      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "require-uncached": {
@@ -895,9 +895,9 @@
       }
     },
     "shift-spec-idl": {
-      "version": "2016.0.0",
-      "resolved": "https://registry.npmjs.org/shift-spec-idl/-/shift-spec-idl-2016.0.0.tgz",
-      "integrity": "sha1-pHSv7oIBirNHdl7iAquywd6rWN0=",
+      "version": "2017.0.0",
+      "resolved": "https://registry.npmjs.org/shift-spec-idl/-/shift-spec-idl-2017.0.0.tgz",
+      "integrity": "sha512-puOJMLy3qUOGN3HkNNDI+/bVpXvNIN7ERf+KIv3JImeewZdo1k/X1GwtJQ/UfIsvd7lFiP4Er4UNzaO9SDZ/yw==",
       "dev": true
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-spec",
-  "version": "2016.0.0",
+  "version": "2017.0.0",
   "description": "JavaScript representation of the Shift AST specification",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-spec-js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "eslint": "^5.6.1",
     "shift-spec-consumer": "1.0.0",
-    "shift-spec-idl": "2016.0.x"
+    "shift-spec-idl": "2017.0.0"
   },
   "bugs": {
     "url": "https://github.com/shapesecurity/shift-spec-js/issues"


### PR DESCRIPTION
Includes version bump commit, so please **rebase**, not merge.

This is based on the `es2017` branch, which I just forked from `es2016`.